### PR TITLE
fix: drawer item selected background

### DIFF
--- a/packages/app_ui/lib/src/widgets/app_logo.dart
+++ b/packages/app_ui/lib/src/widgets/app_logo.dart
@@ -27,7 +27,7 @@ class AppLogo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return _logo.image(
-      fit: BoxFit.cover,
+      fit: BoxFit.contain,
       width: 172,
       height: 24,
     );


### PR DESCRIPTION
Bug occured only on fresh load of the app 

ListView at render time didn't know the height of the image. After the image was created the background layer is not rebuild.

was:
<img width="318" alt="CleanShot 2022-05-19 at 12 06 00@2x" src="https://user-images.githubusercontent.com/17708132/169268675-ca290982-868a-438e-a415-de9a4b8f101a.png">

is:

<img width="290" alt="CleanShot 2022-05-19 at 12 06 31@2x" src="https://user-images.githubusercontent.com/17708132/169268771-08fba65e-5be6-4b55-bf07-347e9c8012f7.png">

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
