### PR TITLE
feat(navigation): show subscribe in NavigationDrawer when user is not subscribed

### DIFF
--- a/lib/app/bloc/app_state.dart
+++ b/lib/app/bloc/app_state.dart
@@ -31,6 +31,10 @@ class AppState extends Equatable {
   final User user;
   final SubscriptionPlan? userSubscriptionPlan;
 
+  bool get isUserSubscribed =>
+      userSubscriptionPlan != null &&
+      userSubscriptionPlan != SubscriptionPlan.none;
+
   @override
   List<Object?> get props => [
         status,

--- a/lib/navigation/view/navigation_drawer.dart
+++ b/lib/navigation/view/navigation_drawer.dart
@@ -1,5 +1,7 @@
 import 'package:app_ui/app_ui.dart' show AppColors, AppSpacing, AppLogo;
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:google_news_template/app/app.dart';
 import 'package:google_news_template/navigation/navigation.dart';
 
 class NavigationDrawer extends StatelessWidget {
@@ -9,6 +11,9 @@ class NavigationDrawer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isUserSubscribed =
+        context.select((AppBloc bloc) => bloc.state.isUserSubscribed);
+
     return ClipRRect(
       borderRadius: const BorderRadius.only(
         topRight: Radius.circular(AppSpacing.lg),
@@ -38,8 +43,10 @@ class NavigationDrawer extends StatelessWidget {
             ),
             const _NavigationDrawerDivider(),
             const NavigationDrawerSections(),
-            const _NavigationDrawerDivider(),
-            const NavigationDrawerSubscribe(),
+            if (!isUserSubscribed) ...[
+              const _NavigationDrawerDivider(),
+              const NavigationDrawerSubscribe(),
+            ],
           ],
         ),
       ),

--- a/test/app/bloc/app_state_test.dart
+++ b/test/app/bloc/app_state_test.dart
@@ -45,6 +45,36 @@ void main() {
       });
     });
 
+    group('isUserSubscribed', () {
+      test('returns true when userSubscriptionPlan is not null and not none',
+          () {
+        expect(
+          AppState.authenticated(
+            MockUser(),
+            userSubscriptionPlan: SubscriptionPlan.premium,
+          ).isUserSubscribed,
+          isTrue,
+        );
+      });
+
+      test('returns false when userSubscriptionPlan is null', () {
+        expect(
+          AppState.authenticated(MockUser()).isUserSubscribed,
+          isFalse,
+        );
+      });
+
+      test('returns false when userSubscriptionPlan is none', () {
+        expect(
+          AppState.authenticated(
+            MockUser(),
+            userSubscriptionPlan: SubscriptionPlan.none,
+          ).isUserSubscribed,
+          isFalse,
+        );
+      });
+    });
+
     group('copyWith', () {
       test(
           'returns same object '


### PR DESCRIPTION
## Description

Closes [#2548210896](https://very-good-ventures-team.monday.com/boards/2370958642/pulses/2548210896).

- feat(navigation): show subscribe in NavigationDrawer when user is not subscribed

| Not subscribed | Subscribed |
|---|---|
| ![Simulator Screen Shot - iPhone 12 - 2022-06-09 at 14 28 54](https://user-images.githubusercontent.com/26686598/172852131-3153cd6d-3d3d-4eb0-9751-51e8fefb7c5f.png) | ![Simulator Screen Shot - iPhone 12 - 2022-06-09 at 14 28 50](https://user-images.githubusercontent.com/26686598/172852116-59c4405f-2d29-4f5f-9631-ea87515aaad2.png) |



## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
