### PR TITLE
chore: add iOS/Android AdMob app id to mason template

### DIFF
--- a/google_news_template/template.json
+++ b/google_news_template/template.json
@@ -15,7 +15,8 @@
       "facebook_app_id": "facebook_app_id",
       "facebook_client_token": "facebook_client_token",
       "facebook_display_name": "facebook_display_name",
-      "admob_app_id": "admob_app_id"
+      "ios_admob_app_id": "ios_admob_app_id",
+      "android_admob_app_id": "android_admob_app_id"
     },
     {
       "name": "production",
@@ -25,7 +26,8 @@
       "facebook_app_id": "facebook_app_id",
       "facebook_client_token": "facebook_client_token",
       "facebook_display_name": "facebook_display_name",
-      "admob_app_id": "admob_app_id"
+      "ios_admob_app_id": "ios_admob_app_id",
+      "android_admob_app_id": "android_admob_app_id"
     }
   ]
 }

--- a/tool/generator/main.dart
+++ b/tool/generator/main.dart
@@ -492,7 +492,7 @@ void main() async {
       isa = XCBuildConfiguration;
       baseConfigurationReference = {{xcconfig_id}} /* {{name}}.xcconfig */;
       buildSettings = {
-        ADMOB_APP_ID = "{{admob_app_id}}";
+        ADMOB_APP_ID = "{{ios_admob_app_id}}";
         ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
         CLANG_ENABLE_MODULES = YES;
         CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
@@ -590,7 +590,7 @@ void main() async {
       isa = XCBuildConfiguration;
       baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
       buildSettings = {
-        ADMOB_APP_ID = "{{admob_app_id}}";
+        ADMOB_APP_ID = "{{ios_admob_app_id}}";
         ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
         CLANG_ENABLE_MODULES = YES;
         CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;

--- a/tool/generator/static/strings.xml
+++ b/tool/generator/static/strings.xml
@@ -4,5 +4,5 @@
     <string name="facebook_client_token">{{flavors.facebook_client_token}}</string>
     <string name="twitter_redirect_uri_scheme">{{flavors.project_name.paramCase()}}</string>
     <string name="flavor_deep_link_domain">{{flavors.deep_link_domain}}</string>
-    <string name="admob_app_id">{{flavors.admob_app_id}}</string>
+    <string name="admob_app_id">{{flavors.android_admob_app_id}}</string>
 </resources>


### PR DESCRIPTION
## Description

- chore: add iOS/Android AdMob app id to mason template

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
