### PR TITLE
fix: add missing JsonSerializable on NewsBlock

### DIFF
--- a/google_news_project/api/packages/news_blocks/lib/src/news_block.dart
+++ b/google_news_project/api/packages/news_blocks/lib/src/news_block.dart
@@ -1,3 +1,4 @@
+import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:news_blocks/news_blocks.dart';
 
@@ -5,6 +6,7 @@ import 'package:news_blocks/news_blocks.dart';
 /// A reusable news block which represents a content-based component.
 /// {@endtemplate}
 @immutable
+@JsonSerializable()
 abstract class NewsBlock {
   /// {@macro news_block}
   const NewsBlock({required this.type});

--- a/google_news_project/api/packages/news_blocks/pubspec.yaml
+++ b/google_news_project/api/packages/news_blocks/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   equatable: ^2.0.3
-  json_annotation: ^4.5.0
+  json_annotation: ^4.6.0
   meta: ^1.7.0
 
 dev_dependencies:


### PR DESCRIPTION
## Description

- fix: add missing JsonSerializable on NewsBlock

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
