### PR TITLE
docs: update outdated VGV repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Flutter automatically supports right-to-left languages when the user changes the
 
 Currently, this project supports multiple ways of authentication such as `email`, `google`, `apple`, `twitter` and `facebook` login.
 
-The current implementation of the login functionality can be found in [FirebaseAuthenticationClient](https://github.com/flutter/news_template/blob/main/google_news_project/packages/authentication_client/firebase_authentication_client/lib/src/firebase_authentication_client.dart#L20) inside the `packages/authentication_client` package.
+The current implementation of the login functionality can be found in [FirebaseAuthenticationClient](https://github.com/flutter/news_template/tree/main/google_news_project/packages/authentication_client/firebase_authentication_client/lib/src/firebase_authentication_client.dart#L20) inside the `packages/authentication_client` package.
 
 The package depends on the third-party packages that expose authentication methods such as:
 


### PR DESCRIPTION

## Description

The `README.md` contained numerous links to the old VGV repository location. Updated them to the hopefully analogous locations in the new `flutter/news_template` repository.

TODO(@felangel): The updated targets are going to need to be sanity tested

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
