### PR TITLE
Super Editor prototype for article rendering and interaction

### DIFF
--- a/flutter_news_example/api/lib/src/client/flutter_news_example_api_client.dart
+++ b/flutter_news_example/api/lib/src/client/flutter_news_example_api_client.dart
@@ -60,7 +60,7 @@ class FlutterNewsExampleApiClient {
     http.Client? httpClient,
     required TokenProvider tokenProvider,
   }) : this._(
-          baseUrl: 'http://localhost:8080',
+          baseUrl: 'http://10.0.2.2:8080', //'http://localhost:8080',
           httpClient: httpClient,
           tokenProvider: tokenProvider,
         );

--- a/flutter_news_example/lib/article/view/article_page.dart
+++ b/flutter_news_example/lib/article/view/article_page.dart
@@ -8,8 +8,10 @@ import 'package:flutter_news_example/app/app.dart';
 import 'package:flutter_news_example/article/article.dart';
 import 'package:flutter_news_example/l10n/l10n.dart';
 import 'package:flutter_news_example/subscriptions/subscriptions.dart';
+import 'package:flutter_news_example/super_editor_article/super_editor_article.dart';
 import 'package:news_blocks_ui/news_blocks_ui.dart';
 import 'package:share_launcher/share_launcher.dart';
+import 'package:super_editor/super_editor.dart';
 
 class ArticlePage extends StatelessWidget {
   const ArticlePage({
@@ -71,13 +73,10 @@ class _ArticleViewState extends State<ArticleView> {
 
   @override
   Widget build(BuildContext context) {
-    final backgroundColor =
-        widget.isVideoArticle ? AppColors.darkBackground : AppColors.white;
-    final foregroundColor =
-        widget.isVideoArticle ? AppColors.white : AppColors.highEmphasisSurface;
+    final backgroundColor = widget.isVideoArticle ? AppColors.darkBackground : AppColors.white;
+    final foregroundColor = widget.isVideoArticle ? AppColors.white : AppColors.highEmphasisSurface;
     final uri = context.select((ArticleBloc bloc) => bloc.state.uri);
-    final isSubscriber =
-        context.select<AppBloc, bool>((bloc) => bloc.state.isUserSubscribed);
+    final isSubscriber = context.select<AppBloc, bool>((bloc) => bloc.state.isUserSubscribed);
 
     return HasReachedArticleLimitListener(
       child: HasWatchedRewardedAdListener(
@@ -85,14 +84,10 @@ class _ArticleViewState extends State<ArticleView> {
           backgroundColor: backgroundColor,
           appBar: AppBar(
             systemOverlayStyle: SystemUiOverlayStyle(
-              statusBarIconBrightness:
-                  widget.isVideoArticle ? Brightness.light : Brightness.dark,
-              statusBarBrightness:
-                  widget.isVideoArticle ? Brightness.dark : Brightness.light,
+              statusBarIconBrightness: widget.isVideoArticle ? Brightness.light : Brightness.dark,
+              statusBarBrightness: widget.isVideoArticle ? Brightness.dark : Brightness.light,
             ),
-            leading: widget.isVideoArticle
-                ? const AppBackButton.light()
-                : const AppBackButton(),
+            leading: widget.isVideoArticle ? const AppBackButton.light() : const AppBackButton(),
             actions: [
               if (uri != null && uri.toString().isNotEmpty)
                 Padding(
@@ -101,9 +96,7 @@ class _ArticleViewState extends State<ArticleView> {
                   child: ShareButton(
                     shareText: context.l10n.shareText,
                     color: foregroundColor,
-                    onPressed: () => context
-                        .read<ArticleBloc>()
-                        .add(ShareRequested(uri: uri)),
+                    onPressed: () => context.read<ArticleBloc>().add(ShareRequested(uri: uri)),
                   ),
                 ),
               if (!isSubscriber) const ArticleSubscribeButton()
@@ -111,7 +104,9 @@ class _ArticleViewState extends State<ArticleView> {
           ),
           body: ArticleThemeOverride(
             isVideoArticle: widget.isVideoArticle,
-            child: const ArticleContent(),
+            // child: const ArticleContent(),
+            // ^ original article implementation
+            child: const SuperEditorArticle(),
           ),
         ),
       ),
@@ -152,9 +147,7 @@ class HasReachedArticleLimitListener extends StatelessWidget {
           context.read<ArticleBloc>().add(const ArticleRequested());
         }
       },
-      listenWhen: (previous, current) =>
-          previous.hasReachedArticleViewsLimit !=
-          current.hasReachedArticleViewsLimit,
+      listenWhen: (previous, current) => previous.hasReachedArticleViewsLimit != current.hasReachedArticleViewsLimit,
       child: child,
     );
   }
@@ -174,8 +167,7 @@ class HasWatchedRewardedAdListener extends StatelessWidget {
           context.read<ArticleBloc>().add(const ArticleRewardedAdWatched());
         }
       },
-      listenWhen: (previous, current) =>
-          previous.earnedReward != current.earnedReward,
+      listenWhen: (previous, current) => previous.earnedReward != current.earnedReward,
       child: child,
     );
   }

--- a/flutter_news_example/lib/super_editor_article/banner_ad.dart
+++ b/flutter_news_example/lib/super_editor_article/banner_ad.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:news_blocks/news_blocks.dart';
+import 'package:news_blocks_ui/src/widgets/widgets.dart';
+import 'package:super_editor/super_editor.dart';
+
+class BannerAdNode extends BlockNode with ChangeNotifier {
+  BannerAdNode({
+    required this.id,
+    required this.size,
+    required this.adFailedToLoadTitle,
+  }) {
+    metadata["blockType"] = bannerAdBlock;
+  }
+
+  @override
+  final String id;
+  final BannerAdSize size;
+  final String adFailedToLoadTitle;
+
+  @override
+  String? copyContent(NodeSelection selection) {
+    return null;
+  }
+}
+
+const bannerAdBlock = NamedAttribution("bannerAd");
+
+class BannerAdComponentBuilder extends ComponentBuilder {
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! BannerAdNode) {
+      return null;
+    }
+
+    return BannerAdViewModel(
+      nodeId: node.id,
+      size: node.size,
+      adFailedToLoadTitle: node.adFailedToLoadTitle,
+    );
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! BannerAdViewModel) {
+      return null;
+    }
+
+    return BannerAdComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}
+
+class BannerAdViewModel extends SingleColumnLayoutComponentViewModel {
+  BannerAdViewModel({
+    required super.nodeId,
+    required this.size,
+    required this.adFailedToLoadTitle,
+    super.maxWidth,
+    super.padding = EdgeInsets.zero,
+  });
+
+  final BannerAdSize size;
+  final String adFailedToLoadTitle;
+
+  @override
+  SingleColumnLayoutComponentViewModel copy() {
+    return BannerAdViewModel(
+      nodeId: nodeId,
+      maxWidth: maxWidth,
+      padding: padding,
+      size: size,
+      adFailedToLoadTitle: adFailedToLoadTitle,
+    );
+  }
+}
+
+class BannerAdComponent extends StatelessWidget {
+  const BannerAdComponent({
+    super.key,
+    required this.viewModel,
+  });
+
+  final BannerAdViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return BannerAdContainer(
+      size: viewModel.size,
+      child: BannerAdContent(
+        size: viewModel.size,
+        adFailedToLoadTitle: viewModel.adFailedToLoadTitle,
+      ),
+    );
+  }
+}

--- a/flutter_news_example/lib/super_editor_article/delete_me_template.dart
+++ b/flutter_news_example/lib/super_editor_article/delete_me_template.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/cupertino.dart';
+import 'package:super_editor/super_editor.dart';
+
+class DeleteMeNode extends BlockNode with ChangeNotifier {
+  DeleteMeNode({
+    required this.id,
+  });
+
+  @override
+  final String id;
+
+  @override
+  String? copyContent(NodeSelection selection) {
+    return null;
+  }
+}
+
+class DeleteMeComponentBuilder extends ComponentBuilder {
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! DeleteMeNode) {
+      return null;
+    }
+
+    return DeleteMeViewModel(nodeId: node.id);
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! DeleteMeViewModel) {
+      return null;
+    }
+
+    return DeleteMeComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}
+
+class DeleteMeViewModel extends SingleColumnLayoutComponentViewModel {
+  DeleteMeViewModel({
+    required super.nodeId,
+    super.maxWidth,
+    super.padding = EdgeInsets.zero,
+  });
+
+  @override
+  SingleColumnLayoutComponentViewModel copy() {
+    return DeleteMeViewModel(
+      nodeId: nodeId,
+      maxWidth: maxWidth,
+      padding: padding,
+    );
+  }
+}
+
+class DeleteMeComponent extends StatelessWidget {
+  const DeleteMeComponent({
+    super.key,
+    required this.viewModel,
+  });
+
+  final DeleteMeViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}

--- a/flutter_news_example/lib/super_editor_article/divider.dart
+++ b/flutter_news_example/lib/super_editor_article/divider.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+class DividerNode extends BlockNode with ChangeNotifier {
+  DividerNode({
+    required this.id,
+  }) {
+    metadata["blockType"] = dividerBlock;
+  }
+
+  @override
+  final String id;
+
+  @override
+  String? copyContent(NodeSelection selection) {
+    return null;
+  }
+}
+
+const dividerBlock = NamedAttribution("divider");
+
+class DividerComponentBuilder extends ComponentBuilder {
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! DividerNode) {
+      return null;
+    }
+
+    return DividerViewModel(nodeId: node.id);
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! DividerViewModel) {
+      return null;
+    }
+
+    return DividerComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}
+
+class DividerViewModel extends SingleColumnLayoutComponentViewModel {
+  DividerViewModel({
+    required super.nodeId,
+    super.maxWidth,
+    super.padding = EdgeInsets.zero,
+  });
+
+  @override
+  SingleColumnLayoutComponentViewModel copy() {
+    return DividerViewModel(
+      nodeId: nodeId,
+      maxWidth: maxWidth,
+      padding: padding,
+    );
+  }
+}
+
+class DividerComponent extends StatelessWidget {
+  const DividerComponent({
+    super.key,
+    required this.viewModel,
+  });
+
+  final DividerViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return const Divider();
+  }
+}

--- a/flutter_news_example/lib/super_editor_article/news_document.dart
+++ b/flutter_news_example/lib/super_editor_article/news_document.dart
@@ -1,0 +1,236 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_news_example/l10n/l10n.dart';
+import 'package:flutter_news_example/super_editor_article/banner_ad.dart';
+import 'package:flutter_news_example/super_editor_article/divider.dart';
+import 'package:flutter_news_example/super_editor_article/newsletter.dart';
+import 'package:flutter_news_example/super_editor_article/share.dart';
+import 'package:flutter_news_example/super_editor_article/slideshow.dart';
+import 'package:news_blocks/news_blocks.dart';
+import 'package:super_editor/super_editor.dart';
+
+import 'spacer.dart';
+import 'trending_story.dart';
+import 'video.dart';
+
+MutableDocument createNewsDocument(
+  BuildContext context,
+  List<NewsBlock> blocks, {
+  VoidCallback? onSharePressed,
+}) {
+  print("Creating a document...");
+  final document = MutableDocument();
+
+  for (final block in blocks) {
+    print(" - creating node for block: $block");
+    switch (block.type) {
+      case ArticleIntroductionBlock.identifier:
+        print("    - ^ handled!");
+        final intro = block as ArticleIntroductionBlock;
+
+        if (intro.imageUrl != null) {
+          document.add(
+            ImageNode(
+              id: DocumentEditor.createNodeId(),
+              imageUrl: intro.imageUrl!,
+              metadata: {
+                "blockType": "headerImage",
+              },
+            ),
+          );
+        }
+
+        document //
+          ..add(
+            ParagraphNode(
+              id: DocumentEditor.createNodeId(),
+              text: AttributedText(
+                text: intro.category.name.toUpperCase(),
+              ),
+              metadata: {
+                "blockType": categoryBlock,
+              },
+            ),
+          )
+          ..add(
+            ParagraphNode(
+              id: DocumentEditor.createNodeId(),
+              text: AttributedText(
+                text: intro.title,
+              ),
+              metadata: {
+                "blockType": titleBlock,
+              },
+            ),
+          )
+          ..add(
+            ParagraphNode(
+              id: DocumentEditor.createNodeId(),
+              text: AttributedText(
+                text: "${intro.publishedAt.mDY} • ${intro.author}",
+              ),
+              metadata: {
+                "blockType": byLineBlock,
+              },
+            ),
+          )
+          ..add(
+            ShareNode(
+              id: DocumentEditor.createNodeId(),
+              shareText: context.l10n.shareText,
+              onSharePressed: onSharePressed,
+            ),
+          );
+
+        break;
+      case ImageBlock.identifier:
+        print("    - ^ handled!");
+        document.add(
+          ImageNode(
+            id: DocumentEditor.createNodeId(),
+            imageUrl: (block as ImageBlock).imageUrl,
+          ),
+        );
+        break;
+      case TextLeadParagraphBlock.identifier:
+        print("    - ^ handled!");
+        final textLeadBlock = block as TextLeadParagraphBlock;
+        document.add(
+          ParagraphNode(
+            id: DocumentEditor.createNodeId(),
+            text: AttributedText(
+              text: textLeadBlock.text,
+              spans: AttributedSpans(
+                attributions: [
+                  SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
+                  SpanMarker(
+                      attribution: boldAttribution,
+                      offset: textLeadBlock.text.length - 1,
+                      markerType: SpanMarkerType.end),
+                ],
+              ),
+            ),
+            metadata: {
+              "blockType": const NamedAttribution(TextLeadParagraphBlock.identifier),
+            },
+          ),
+        );
+        break;
+      case TextHeadlineBlock.identifier:
+        print("    - ^ handled!");
+        final textLeadBlock = block as TextHeadlineBlock;
+        document.add(
+          ParagraphNode(
+            id: DocumentEditor.createNodeId(),
+            text: AttributedText(
+              text: textLeadBlock.text,
+            ),
+            metadata: {
+              "blockType": header1Attribution,
+            },
+          ),
+        );
+        break;
+      case TextParagraphBlock.identifier:
+        print("    - ^ handled!");
+        final textLeadBlock = block as TextParagraphBlock;
+        document.add(
+          ParagraphNode(
+            id: DocumentEditor.createNodeId(),
+            text: AttributedText(
+              text: textLeadBlock.text,
+            ),
+          ),
+        );
+        break;
+      case TextCaptionBlock.identifier:
+        print("    - ^ handled!");
+        final caption = block as TextCaptionBlock;
+        document.add(
+          ParagraphNode(
+            id: DocumentEditor.createNodeId(),
+            text: AttributedText(
+              text: caption.text,
+            ),
+            metadata: {
+              "blockType": block.color == TextCaptionColor.normal //
+                  ? normalCaptionBlock
+                  : lightCaptionBlock,
+            },
+          ),
+        );
+        break;
+      case VideoBlock.identifier:
+        print("    - ^ handled!");
+        final video = block as VideoBlock;
+        document.add(
+          VideoNode(id: DocumentEditor.createNodeId(), videoUrl: video.videoUrl),
+        );
+        break;
+      case SlideshowIntroductionBlock.identifier:
+        print("    - ^ handled!");
+        final slideshow = block as SlideshowIntroductionBlock;
+        document.add(
+          SlideshowNode(
+            id: DocumentEditor.createNodeId(),
+            coverImageUrl: slideshow.coverImageUrl,
+            slideshowText: context.l10n.slideshow,
+            title: slideshow.title,
+          ),
+        );
+        break;
+      case BannerAdBlock.identifier:
+        print("    - ^ handled!");
+        final bannerAd = block as BannerAdBlock;
+        document.add(
+          BannerAdNode(
+            id: DocumentEditor.createNodeId(),
+            size: bannerAd.size,
+            adFailedToLoadTitle: context.l10n.adLoadFailure,
+          ),
+        );
+        break;
+      case NewsletterBlock.identifier:
+        print("    - ^ handled!");
+        document.add(NewsletterNode(id: DocumentEditor.createNodeId()));
+        break;
+      case TrendingStoryBlock.identifier:
+        print("    - ^ handled!");
+        final trendingStory = block as TrendingStoryBlock;
+        document.add(
+          TrendingStoryNode(
+            id: DocumentEditor.createNodeId(),
+            title: context.l10n.trendingStoryTitle,
+            content: trendingStory.content,
+          ),
+        );
+        break;
+      case DividerHorizontalBlock.identifier:
+        print("    - ^ handled!");
+        document.add(DividerNode(id: DocumentEditor.createNodeId()));
+        break;
+      case SpacerBlock.identifier:
+        print("    - ^ handled!");
+        final spacer = block as SpacerBlock;
+        document.add(
+          SpacerNode(
+            id: DocumentEditor.createNodeId(),
+            spacing: spacer.spacing,
+          ),
+        );
+        break;
+      default:
+        break;
+    }
+  }
+  print("Done creating document");
+
+  return document;
+}
+
+const categoryBlock = NamedAttribution("category");
+const titleBlock = NamedAttribution("title");
+const byLineBlock = NamedAttribution("byLine");
+const normalCaptionBlock = NamedAttribution("captionNormal");
+const lightCaptionBlock = NamedAttribution("captionLight");

--- a/flutter_news_example/lib/super_editor_article/news_stylesheet.dart
+++ b/flutter_news_example/lib/super_editor_article/news_stylesheet.dart
@@ -1,0 +1,163 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_news_example/article/widgets/article_theme_override.dart';
+import 'package:flutter_news_example/super_editor_article/banner_ad.dart';
+import 'package:flutter_news_example/super_editor_article/divider.dart';
+import 'package:flutter_news_example/super_editor_article/newsletter.dart';
+import 'package:flutter_news_example/super_editor_article/slideshow.dart';
+import 'package:flutter_news_example/super_editor_article/trending_story.dart';
+import 'package:news_blocks/news_blocks.dart';
+import 'package:super_editor/super_editor.dart';
+
+import 'news_document.dart';
+import 'share.dart';
+
+Stylesheet createNewsStylesheet(BuildContext context) {
+  return Stylesheet(
+    documentPadding: EdgeInsets.zero,
+    inlineTextStyler: defaultInlineTextStyler,
+    rules: [
+      StyleRule(
+        BlockSelector.all,
+        (doc, docNode) {
+          return {
+            "maxWidth": double.infinity,
+            "padding": const CascadingPadding.symmetric(horizontal: AppSpacing.lg),
+            "textStyle": Theme.of(context).textTheme.bodyText1,
+          };
+        },
+      ),
+      StyleRule(
+        const BlockSelector("image").atIndex(0),
+        (doc, docNode) {
+          return {
+            "padding": const CascadingPadding.only(left: 0, right: 0, bottom: 16),
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(shareBlock.name),
+        (doc, docNode) {
+          return {
+            "padding": const CascadingPadding.all(0),
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(header1Attribution.name),
+        (doc, docNode) {
+          return {
+            "textStyle": Theme.of(context).textTheme.headline2,
+          };
+        },
+      ),
+      StyleRule(
+        const BlockSelector(TextLeadParagraphBlock.identifier),
+        (doc, docNode) {
+          return {
+            "textStyle": Theme.of(context).textTheme.headline6,
+          };
+        },
+      ),
+      StyleRule(
+        const BlockSelector("paragraph"),
+        (doc, docNode) {
+          return {
+            "textStyle": Theme.of(context).textTheme.bodyText1,
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(categoryBlock.name),
+        (doc, docNode) {
+          return {
+            "padding": const CascadingPadding.only(bottom: 8),
+            "textStyle": Theme.of(context).textTheme.overline!.copyWith(
+                  color: AppColors.secondary,
+                ),
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(titleBlock.name),
+        (doc, docNode) {
+          return {
+            "padding": const CascadingPadding.only(bottom: 12),
+            "textStyle": Theme.of(context).textTheme.headline3,
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(byLineBlock.name),
+        (doc, docNode) {
+          return {
+            "padding": const CascadingPadding.only(bottom: 32),
+            "textStyle": Theme.of(context).textTheme.caption,
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(normalCaptionBlock.name),
+        (doc, docNode) {
+          return {
+            "textStyle": Theme.of(context).textTheme.caption?.apply(
+                  color:
+                      Theme.of(context).extension<ArticleThemeColors>()?.captionNormal ?? AppColors.highEmphasisSurface,
+                ),
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(lightCaptionBlock.name),
+        (doc, docNode) {
+          return {
+            "textStyle": Theme.of(context).textTheme.caption?.apply(
+                  color:
+                      Theme.of(context).extension<ArticleThemeColors>()?.captionLight ?? AppColors.highEmphasisSurface,
+                ),
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(slideshowBlock.name),
+        (doc, docNode) {
+          return {
+            "padding": const CascadingPadding.symmetric(horizontal: AppSpacing.lg),
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(newsletterBlock.name),
+        (doc, docNode) {
+          return {
+            "padding": const CascadingPadding.all(0),
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(bannerAdBlock.name),
+        (doc, docNode) {
+          return {
+            "padding": const CascadingPadding.all(0),
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(trendingStoryBlock.name),
+        (doc, docNode) {
+          return {
+            "padding": const CascadingPadding.all(0),
+          };
+        },
+      ),
+      StyleRule(
+        BlockSelector(dividerBlock.name),
+        (doc, docNode) {
+          return {
+            "padding": const CascadingPadding.all(0),
+          };
+        },
+      ),
+    ],
+  );
+}

--- a/flutter_news_example/lib/super_editor_article/newsletter.dart
+++ b/flutter_news_example/lib/super_editor_article/newsletter.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_news_example/newsletter/newsletter.dart';
+import 'package:super_editor/super_editor.dart';
+
+class NewsletterNode extends BlockNode with ChangeNotifier {
+  NewsletterNode({
+    required this.id,
+  }) {
+    metadata["blockType"] = newsletterBlock;
+  }
+
+  @override
+  final String id;
+
+  @override
+  String? copyContent(NodeSelection selection) {
+    return null;
+  }
+}
+
+const newsletterBlock = NamedAttribution("newsletter");
+
+class NewsletterComponentBuilder extends ComponentBuilder {
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! NewsletterNode) {
+      return null;
+    }
+
+    return NewsletterViewModel(nodeId: node.id);
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! NewsletterViewModel) {
+      return null;
+    }
+
+    return NewsletterComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}
+
+class NewsletterViewModel extends SingleColumnLayoutComponentViewModel {
+  NewsletterViewModel({
+    required super.nodeId,
+    super.maxWidth,
+    super.padding = EdgeInsets.zero,
+  });
+
+  @override
+  SingleColumnLayoutComponentViewModel copy() {
+    return NewsletterViewModel(
+      nodeId: nodeId,
+      maxWidth: maxWidth,
+      padding: padding,
+    );
+  }
+}
+
+class NewsletterComponent extends StatelessWidget {
+  const NewsletterComponent({
+    super.key,
+    required this.viewModel,
+  });
+
+  final NewsletterViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return const Newsletter();
+  }
+}

--- a/flutter_news_example/lib/super_editor_article/share.dart
+++ b/flutter_news_example/lib/super_editor_article/share.dart
@@ -1,0 +1,111 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:news_blocks_ui/news_blocks_ui.dart';
+import 'package:super_editor/super_editor.dart';
+
+class ShareNode extends BlockNode with ChangeNotifier {
+  ShareNode({
+    required this.id,
+    required this.shareText,
+    this.onSharePressed,
+  }) {
+    metadata["blockType"] = shareBlock;
+  }
+
+  @override
+  final String id;
+  final String shareText;
+  final VoidCallback? onSharePressed;
+
+  @override
+  String? copyContent(NodeSelection selection) {
+    return null;
+  }
+}
+
+const shareBlock = NamedAttribution("share");
+
+class ShareComponentBuilder extends ComponentBuilder {
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! ShareNode) {
+      return null;
+    }
+
+    return ShareViewModel(
+      nodeId: node.id,
+      shareText: node.shareText,
+      onSharePressed: node.onSharePressed,
+    );
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! ShareViewModel) {
+      return null;
+    }
+
+    return ShareComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}
+
+class ShareViewModel extends SingleColumnLayoutComponentViewModel {
+  ShareViewModel({
+    required super.nodeId,
+    required this.shareText,
+    this.onSharePressed,
+    super.maxWidth,
+    super.padding = EdgeInsets.zero,
+  });
+
+  final String shareText;
+  final VoidCallback? onSharePressed;
+
+  @override
+  SingleColumnLayoutComponentViewModel copy() {
+    return ShareViewModel(
+      nodeId: nodeId,
+      shareText: shareText,
+      onSharePressed: onSharePressed,
+      maxWidth: maxWidth,
+      padding: padding,
+    );
+  }
+}
+
+class ShareComponent extends StatelessWidget {
+  const ShareComponent({
+    super.key,
+    required this.viewModel,
+  });
+
+  final ShareViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const Divider(),
+        if (viewModel.onSharePressed != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: ShareButton(
+                key: const Key('articleIntroduction_shareButton'),
+                shareText: viewModel.shareText,
+                color: AppColors.darkAqua,
+                onPressed: viewModel.onSharePressed!,
+              ),
+            ),
+          ),
+        const Divider(),
+        const SizedBox(height: AppSpacing.lg),
+      ],
+    );
+  }
+}

--- a/flutter_news_example/lib/super_editor_article/slideshow.dart
+++ b/flutter_news_example/lib/super_editor_article/slideshow.dart
@@ -1,0 +1,136 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:news_blocks_ui/news_blocks_ui.dart';
+import 'package:news_blocks_ui/src/widgets/widgets.dart';
+import 'package:super_editor/super_editor.dart';
+
+class SlideshowNode extends BlockNode with ChangeNotifier {
+  SlideshowNode({
+    required this.id,
+    required this.coverImageUrl,
+    required this.slideshowText,
+    required this.title,
+  }) {
+    metadata["blockType"] = slideshowBlock;
+  }
+
+  @override
+  final String id;
+
+  final String coverImageUrl;
+  final String slideshowText;
+  final String title;
+
+  @override
+  String? copyContent(NodeSelection selection) {
+    return null;
+  }
+}
+
+const slideshowBlock = NamedAttribution("slideshow");
+
+class SlideshowComponentBuilder extends ComponentBuilder {
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! SlideshowNode) {
+      return null;
+    }
+
+    return SlideshowViewModel(
+      nodeId: node.id,
+      coverImageUrl: node.coverImageUrl,
+      slideshowText: node.slideshowText,
+      title: node.title,
+    );
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! SlideshowViewModel) {
+      return null;
+    }
+
+    return SlideshowComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}
+
+class SlideshowViewModel extends SingleColumnLayoutComponentViewModel {
+  SlideshowViewModel({
+    required super.nodeId,
+    super.maxWidth,
+    super.padding = EdgeInsets.zero,
+    required this.coverImageUrl,
+    required this.slideshowText,
+    required this.title,
+  });
+
+  final String coverImageUrl;
+  final String slideshowText;
+  final String title;
+
+  @override
+  SingleColumnLayoutComponentViewModel copy() {
+    return SlideshowViewModel(
+      nodeId: nodeId,
+      maxWidth: maxWidth,
+      padding: padding,
+      coverImageUrl: coverImageUrl,
+      slideshowText: slideshowText,
+      title: title,
+    );
+  }
+}
+
+class SlideshowComponent extends StatelessWidget {
+  const SlideshowComponent({
+    super.key,
+    required this.viewModel,
+  });
+
+  final SlideshowViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return GestureDetector(
+      onTap: () {
+        // TODO:
+      },
+      child: Stack(
+        alignment: Alignment.bottomLeft,
+        children: [
+          PostLargeImage(
+            imageUrl: viewModel.coverImageUrl,
+            isContentOverlaid: true,
+            isLocked: false,
+          ),
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SlideshowCategory(slideshowText: viewModel.slideshowText),
+                const SizedBox(
+                  height: AppSpacing.xs,
+                ),
+                Text(
+                  viewModel.title,
+                  style: textTheme.headline2?.copyWith(
+                    color: AppColors.highEmphasisPrimary,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_news_example/lib/super_editor_article/spacer.dart
+++ b/flutter_news_example/lib/super_editor_article/spacer.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/widgets.dart';
+import 'package:news_blocks/news_blocks.dart';
+import 'package:super_editor/super_editor.dart';
+
+class SpacerNode extends BlockNode with ChangeNotifier {
+  SpacerNode({
+    required this.id,
+    required this.spacing,
+  });
+
+  @override
+  final String id;
+
+  final Spacing spacing;
+
+  @override
+  String? copyContent(NodeSelection selection) {
+    return null;
+  }
+}
+
+class SpacerViewModel extends SingleColumnLayoutComponentViewModel {
+  SpacerViewModel({
+    required super.nodeId,
+    super.maxWidth,
+    super.padding = EdgeInsets.zero,
+    required this.spacing,
+  });
+
+  final Spacing spacing;
+
+  @override
+  SingleColumnLayoutComponentViewModel copy() {
+    return SpacerViewModel(
+      nodeId: nodeId,
+      maxWidth: maxWidth,
+      padding: padding,
+      spacing: spacing,
+    );
+  }
+}
+
+class SpacerComponentBuilder implements ComponentBuilder {
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! SpacerNode) {
+      return null;
+    }
+
+    return SpacerViewModel(
+      nodeId: node.id,
+      spacing: node.spacing,
+    );
+  }
+
+  @override
+  Widget? createComponent(
+    SingleColumnDocumentComponentContext componentContext,
+    SingleColumnLayoutComponentViewModel componentViewModel,
+  ) {
+    if (componentViewModel is! SpacerViewModel) {
+      return null;
+    }
+
+    return SpacerComponent(
+      key: componentContext.componentKey,
+      spacing: componentViewModel.spacing,
+    );
+  }
+}
+
+class SpacerComponent extends StatelessWidget {
+  static const _spacingValues = <Spacing, double>{
+    Spacing.extraSmall: 4,
+    Spacing.small: 8,
+    Spacing.medium: 16,
+    Spacing.large: 32,
+    Spacing.veryLarge: 48,
+    Spacing.extraLarge: 64,
+  };
+
+  const SpacerComponent({
+    super.key,
+    required this.spacing,
+  });
+
+  final Spacing spacing;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: _spacingValues[spacing],
+    );
+  }
+}

--- a/flutter_news_example/lib/super_editor_article/super_editor_article.dart
+++ b/flutter_news_example/lib/super_editor_article/super_editor_article.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart' hide ProgressIndicator;
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_news_example/ads/widgets/sticky_ad.dart';
+import 'package:flutter_news_example/article/article.dart';
+import 'package:flutter_news_example/l10n/l10n.dart';
+import 'package:flutter_news_example/network_error/network_error.dart';
+import 'package:flutter_news_example/super_editor_article/banner_ad.dart';
+import 'package:flutter_news_example/super_editor_article/divider.dart';
+import 'package:flutter_news_example/super_editor_article/newsletter.dart';
+import 'package:flutter_news_example/super_editor_article/share.dart';
+import 'package:flutter_news_example/super_editor_article/slideshow.dart';
+import 'package:flutter_news_example/super_editor_article/trending_story.dart';
+import 'package:super_editor/super_editor.dart';
+
+import 'news_document.dart';
+import 'news_stylesheet.dart';
+import 'spacer.dart';
+import 'video.dart';
+
+class SuperEditorArticle extends StatefulWidget {
+  const SuperEditorArticle({super.key});
+
+  @override
+  State<SuperEditorArticle> createState() => _SuperEditorArticleState();
+}
+
+class _SuperEditorArticleState extends State<SuperEditorArticle> {
+  @override
+  Widget build(BuildContext context) {
+    final content = context.select((ArticleBloc bloc) => bloc.state.content);
+    final uri = context.select((ArticleBloc bloc) => bloc.state.uri);
+
+    final onSharePressed = uri != null && uri.toString().isNotEmpty
+        ? () => context.read<ArticleBloc>().add(
+              ShareRequested(uri: uri),
+            )
+        : null;
+
+    final document = createNewsDocument(
+      context,
+      content,
+      onSharePressed: onSharePressed,
+    );
+    final stylesheet = createNewsStylesheet(context);
+
+    return ArticleContentSeenListener(
+      child: BlocListener<ArticleBloc, ArticleState>(
+        listener: (context, state) {
+          if (state.status == ArticleStatus.failure && state.content.isEmpty) {
+            Navigator.of(context).push<void>(
+              NetworkError.route(
+                onRetry: () {
+                  context.read<ArticleBloc>().add(const ArticleRequested());
+                  Navigator.of(context).pop();
+                },
+              ),
+            );
+          } else if (state.status == ArticleStatus.shareFailure) {
+            _handleShareFailure(context);
+          }
+        },
+        child: Stack(
+          alignment: AlignmentDirectional.bottomCenter,
+          children: [
+            SingleChildScrollView(
+              child: Column(
+                children: [
+                  SuperReader(
+                    document: document,
+                    componentBuilders: _componentBuilders,
+                    stylesheet: stylesheet,
+                  ),
+                  const ArticleTrailingContent(),
+                ],
+              ),
+            ),
+            const StickyAd(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _handleShareFailure(BuildContext context) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          key: const Key('articleContent_shareFailure_snackBar'),
+          content: Text(
+            context.l10n.shareFailure,
+          ),
+        ),
+      );
+  }
+}
+
+final _componentBuilders = [
+  ...defaultComponentBuilders,
+  ShareComponentBuilder(),
+  VideoComponentBuilder(),
+  SlideshowComponentBuilder(),
+  BannerAdComponentBuilder(),
+  NewsletterComponentBuilder(),
+  TrendingStoryComponentBuilder(),
+  DividerComponentBuilder(),
+  SpacerComponentBuilder(),
+];

--- a/flutter_news_example/lib/super_editor_article/trending_story.dart
+++ b/flutter_news_example/lib/super_editor_article/trending_story.dart
@@ -1,0 +1,111 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:news_blocks/news_blocks.dart';
+import 'package:news_blocks_ui/news_blocks_ui.dart';
+import 'package:super_editor/super_editor.dart';
+
+class TrendingStoryNode extends BlockNode with ChangeNotifier {
+  TrendingStoryNode({
+    required this.id,
+    required this.title,
+    required this.content,
+  }) {
+    metadata["blockType"] = trendingStoryBlock;
+  }
+
+  @override
+  final String id;
+  final String title;
+  final PostSmallBlock content;
+
+  @override
+  String? copyContent(NodeSelection selection) {
+    return null;
+  }
+}
+
+const trendingStoryBlock = NamedAttribution("trendingStory");
+
+class TrendingStoryComponentBuilder extends ComponentBuilder {
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! TrendingStoryNode) {
+      return null;
+    }
+
+    return TrendingStoryViewModel(
+      nodeId: node.id,
+      title: node.title,
+      content: node.content,
+    );
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! TrendingStoryViewModel) {
+      return null;
+    }
+
+    return TrendingStoryComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}
+
+class TrendingStoryViewModel extends SingleColumnLayoutComponentViewModel {
+  TrendingStoryViewModel({
+    required super.nodeId,
+    required this.title,
+    required this.content,
+    super.maxWidth,
+    super.padding = EdgeInsets.zero,
+  });
+
+  final String title;
+  final PostSmallBlock content;
+
+  @override
+  SingleColumnLayoutComponentViewModel copy() {
+    return TrendingStoryViewModel(
+      nodeId: nodeId,
+      title: title,
+      content: content,
+      maxWidth: maxWidth,
+      padding: padding,
+    );
+  }
+}
+
+class TrendingStoryComponent extends StatelessWidget {
+  const TrendingStoryComponent({
+    super.key,
+    required this.viewModel,
+  });
+
+  final TrendingStoryViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context).textTheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(
+            left: AppSpacing.lg,
+            top: AppSpacing.md,
+          ),
+          child: Text(
+            viewModel.title,
+            style: theme.overline?.apply(color: AppColors.secondary),
+          ),
+        ),
+        PostSmall(block: viewModel.content)
+      ],
+    );
+  }
+}

--- a/flutter_news_example/lib/super_editor_article/video.dart
+++ b/flutter_news_example/lib/super_editor_article/video.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/widgets.dart';
+import 'package:news_blocks_ui/src/widgets/widgets.dart';
+import 'package:super_editor/super_editor.dart';
+
+class VideoNode extends BlockNode with ChangeNotifier {
+  VideoNode({
+    required this.id,
+    required this.videoUrl,
+  });
+
+  @override
+  final String id;
+
+  final String videoUrl;
+
+  @override
+  String? copyContent(NodeSelection selection) {
+    return null;
+  }
+}
+
+class VideoComponentBuilder extends ComponentBuilder {
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! VideoNode) {
+      return null;
+    }
+
+    return VideoViewModel(nodeId: node.id, videoUrl: node.videoUrl);
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! VideoViewModel) {
+      return null;
+    }
+
+    return VideoComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}
+
+class VideoViewModel extends SingleColumnLayoutComponentViewModel {
+  VideoViewModel({
+    required super.nodeId,
+    required this.videoUrl,
+    super.maxWidth,
+    super.padding = EdgeInsets.zero,
+  });
+
+  final String videoUrl;
+
+  @override
+  SingleColumnLayoutComponentViewModel copy() {
+    return VideoViewModel(
+      nodeId: nodeId,
+      videoUrl: videoUrl,
+      maxWidth: maxWidth,
+      padding: padding,
+    );
+  }
+}
+
+class VideoComponent extends StatelessWidget {
+  const VideoComponent({
+    super.key,
+    required this.viewModel,
+  });
+
+  final VideoViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return InlineVideo(
+      videoUrl: viewModel.videoUrl,
+      progressIndicator: const ProgressIndicator(),
+    );
+  }
+}

--- a/flutter_news_example/pubspec.lock
+++ b/flutter_news_example/pubspec.lock
@@ -71,6 +71,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.9.0"
+  attributed_text:
+    dependency: transitive
+    description:
+      name: attributed_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   authentication_client:
     dependency: "direct main"
     description:
@@ -590,6 +597,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_test_robots:
+    dependency: transitive
+    description:
+      name: flutter_test_robots
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.17"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -805,6 +819,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.5.4"
+  linkify:
+    dependency: transitive
+    description:
+      name: linkify
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.1.0"
   logging:
     dependency: transitive
     description:
@@ -1363,6 +1384,22 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
+  super_editor:
+    dependency: "direct main"
+    description:
+      path: super_editor
+      ref: stable
+      resolved-ref: cf1ec88272f2fc98f1a9232a8f7b6eb4f0c77bee
+      url: "https://github.com/superlistapp/super_editor"
+    source: git
+    version: "0.2.3+1"
+  super_text_layout:
+    dependency: transitive
+    description:
+      name: super_text_layout
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   synchronized:
     dependency: transitive
     description:

--- a/flutter_news_example/pubspec.yaml
+++ b/flutter_news_example/pubspec.yaml
@@ -77,6 +77,11 @@ dependencies:
     path: packages/share_launcher
   shared_preferences: ^2.0.15
   stream_transform: ^2.0.0
+  super_editor:
+    git:
+      url: https://github.com/superlistapp/super_editor
+      path: super_editor
+      ref: stable
   test: ^1.21.4
   token_storage:
     path: packages/authentication_client/token_storage


### PR DESCRIPTION
This PR is a prototype that demonstrates that Super Editor can be used to render articles in the News Toolkit.

Super Editor benefits:

- Explicit document structure representation, which better reflects existing industry practices for document modeling
- Stylesheet support, which better reflects existing industry document styling practices
- Deep support for inline styling and metadata, e.g., bold, italics, links, font changes, all within a single block of text
- Mobile-style content selection, including selection highlights, drag handles, a magnifier, and auto-scrolling
- Alignment with the community on a package that was initiated by Chris Sells, that's funded by multiple companies, managed by the Flutter Bounty Hunters, and receives contributions from other community members

PR notes:

- This PR is a prototype. Nothing is optimized. Some minor features are missing. Lots of lint complaints.
- This PR uses the existing News Toolkit document structure.
- This PR uses the existing widget implementations for non-standard content, e.g., banner ads, videos, newsletters.
- Super Editor might lack some needed features. As those are located, our team is dedicated to quickly providing solutions.

## Video of the original article implementation

https://user-images.githubusercontent.com/7259036/204066968-4337d3ab-29c8-4d98-a2b1-dcea9412166d.mov


## Video of the Super Editor implementation

https://user-images.githubusercontent.com/7259036/204066990-c15a6ba0-e841-4a39-a500-f53170fb9a5d.mov



