### PR TITLE
docs: minor update on accessing the API

### DIFF
--- a/docs/docs/project_configuration/api_deployment.md
+++ b/docs/docs/project_configuration/api_deployment.md
@@ -27,7 +27,7 @@ By default your app expects to receive news data from `localhost`. In order to r
 
 :::note
 
-If you are using android emulator, you need to set `https://10.0.2.2:8080` as your `_baseURl` instead of `http://localhost:8080`. Android emulator uses the the current machine localhost i.e `127.0.0.1` or `localhost` as the localhost.
+If you are using an android emulator, you must set `https://10.0.2.2:8080` as the `_baseURl` instead of `http://localhost:8080`.
 
 :::
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Android emulator uses the current machine localhost i.e `127.0.0.1` or `localhost` as the localhost. However, Android emulator needs to reach out `https://10.0.2.2:8080` instead of `http://localhost:8080`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ x ] 📝 Documentation
- [ ] 🗑️ Chore
