### PR TITLE
Fixes in-app-purchase cancel flow

### DIFF
--- a/flutter_news_example/packages/in_app_purchase_repository/lib/src/in_app_purchase_repository.dart
+++ b/flutter_news_example/packages/in_app_purchase_repository/lib/src/in_app_purchase_repository.dart
@@ -257,7 +257,8 @@ class InAppPurchaseRepository {
     }
 
     try {
-      if (purchase.pendingCompletePurchase) {
+      if (purchase.pendingCompletePurchase && 
+          purchase.status != PurchaseStatus.canceled) {
         final purchasedSubscription = (await fetchSubscriptions()).firstWhere(
           (subscription) => subscription.id == purchase.productID,
         );


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

On iOS, after showing the payment sheet and pressing on close icon (top right) to cancel payment, the `purchase.pendingCompletePurchase` will be `true` and therefore it will try to call `_inAppPurchase.completePurchase()`. However, it should not do that when the payment is being cancelled.

The `purchase.error` will have an purchase error, which might be checked as well. And for some reason the `purchase.status` is `cancelled` and therefore seams like an unexpected behaviour.

Since I can not open an issue, I'm trying to raise awareness through this PR. Can you check and verify if that is also happening to you?

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
