### PR TITLE
bug: fix issues with first login

### DIFF
--- a/flutter_news_example/lib/app/bloc/app_state.dart
+++ b/flutter_news_example/lib/app/bloc/app_state.dart
@@ -1,9 +1,12 @@
 part of 'app_bloc.dart';
 
 enum AppStatus {
-  onboardingRequired,
-  authenticated,
-  unauthenticated,
+  onboardingRequired(),
+  authenticated(),
+  unauthenticated();
+
+  bool get isLoggedIn =>
+      this == AppStatus.authenticated || this == AppStatus.onboardingRequired;
 }
 
 class AppState extends Equatable {

--- a/flutter_news_example/lib/app/widgets/authenticated_user_listener.dart
+++ b/flutter_news_example/lib/app/widgets/authenticated_user_listener.dart
@@ -15,7 +15,7 @@ class AuthenticatedUserListener extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocListener<AppBloc, AppState>(
       listener: (context, state) {
-        if (state.status == AppStatus.authenticated) {
+        if (state.status.isLoggedIn) {
           context.read<AnalyticsBloc>().add(
                 TrackAnalyticsEvent(
                   state.user.isNewUser ? RegistrationEvent() : LoginEvent(),

--- a/flutter_news_example/lib/login/widgets/login_form.dart
+++ b/flutter_news_example/lib/login/widgets/login_form.dart
@@ -14,7 +14,7 @@ class LoginForm extends StatelessWidget {
     final l10n = context.l10n;
     return BlocListener<AppBloc, AppState>(
       listener: (context, state) {
-        if (state.status == AppStatus.authenticated) {
+        if (state.status.isLoggedIn) {
           // Pop all routes on top of [LoginModal], then pop the modal itself.
           Navigator.of(context)
               .popUntil((route) => route.settings.name == LoginModal.name);

--- a/flutter_news_example/lib/subscriptions/widgets/subscribe_modal.dart
+++ b/flutter_news_example/lib/subscriptions/widgets/subscribe_modal.dart
@@ -25,7 +25,7 @@ class _SubscribeModalState extends State<SubscribeModal> {
     final theme = Theme.of(context);
     final l10n = context.l10n;
     final isLoggedIn = context.select<AppBloc, bool>(
-      (AppBloc bloc) => bloc.state.status == AppStatus.authenticated,
+      (AppBloc bloc) => bloc.state.status.isLoggedIn,
     );
 
     final articleTitle = context.select((ArticleBloc bloc) => bloc.state.title);

--- a/flutter_news_example/lib/subscriptions/widgets/subscribe_with_article_limit_modal.dart
+++ b/flutter_news_example/lib/subscriptions/widgets/subscribe_with_article_limit_modal.dart
@@ -28,8 +28,8 @@ class _SubscribeWithArticleLimitModalState
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
-    final isLoggedIn = context
-        .select((AppBloc bloc) => bloc.state.status == AppStatus.authenticated);
+    final isLoggedIn =
+        context.select((AppBloc bloc) => bloc.state.status.isLoggedIn);
 
     final articleTitle = context.select((ArticleBloc bloc) => bloc.state.title);
 

--- a/flutter_news_example/lib/subscriptions/widgets/subscription_card.dart
+++ b/flutter_news_example/lib/subscriptions/widgets/subscription_card.dart
@@ -35,7 +35,7 @@ class SubscriptionCard extends StatelessWidget {
       subscription.cost.annual / 100,
     );
     final isLoggedIn = context.select<AppBloc, bool>(
-      (AppBloc bloc) => bloc.state.status == AppStatus.authenticated,
+      (AppBloc bloc) => bloc.state.status.isLoggedIn,
     );
 
     return Card(

--- a/flutter_news_example/test/app/bloc/app_state_test.dart
+++ b/flutter_news_example/test/app/bloc/app_state_test.dart
@@ -58,6 +58,20 @@ void main() {
       });
     });
 
+    group('AppStatus', () {
+      test(
+          'authenticated and onboardingRequired are the only statuses when loggedIn it is true',
+          () {
+        expect(
+          AppStatus.values.map((e) => e.isLoggedIn).toList(),
+          [
+            AppStatus.authenticated,
+            AppStatus.onboardingRequired,
+          ],
+        );
+      });
+    });
+
     group('copyWith', () {
       test(
           'returns same object '

--- a/flutter_news_example/test/app/bloc/app_state_test.dart
+++ b/flutter_news_example/test/app/bloc/app_state_test.dart
@@ -61,7 +61,7 @@ void main() {
     group('AppStatus', () {
       test(
           'authenticated and onboardingRequired are the only statuses '
-          'where loggedIn it is true', () {
+          'where loggedIn is true', () {
         expect(
           AppStatus.values.where((e) => e.isLoggedIn).toList(),
           equals(

--- a/flutter_news_example/test/app/bloc/app_state_test.dart
+++ b/flutter_news_example/test/app/bloc/app_state_test.dart
@@ -64,10 +64,12 @@ void main() {
           'where loggedIn it is true', () {
         expect(
           AppStatus.values.where((e) => e.isLoggedIn).toList(),
-          [
-            AppStatus.authenticated,
-            AppStatus.onboardingRequired,
-          ],
+          equals(
+            [
+              AppStatus.authenticated,
+              AppStatus.onboardingRequired,
+            ],
+          ),
         );
       });
     });

--- a/flutter_news_example/test/app/bloc/app_state_test.dart
+++ b/flutter_news_example/test/app/bloc/app_state_test.dart
@@ -60,8 +60,8 @@ void main() {
 
     group('AppStatus', () {
       test(
-          'authenticated and onboardingRequired are the only statuses when loggedIn it is true',
-          () {
+          'authenticated and onboardingRequired are the only statuses '
+          'where loggedIn it is true', () {
         expect(
           AppStatus.values.map((e) => e.isLoggedIn).toList(),
           [

--- a/flutter_news_example/test/app/bloc/app_state_test.dart
+++ b/flutter_news_example/test/app/bloc/app_state_test.dart
@@ -66,8 +66,8 @@ void main() {
           AppStatus.values.where((e) => e.isLoggedIn).toList(),
           equals(
             [
-              AppStatus.authenticated,
               AppStatus.onboardingRequired,
+              AppStatus.authenticated,
             ],
           ),
         );

--- a/flutter_news_example/test/app/bloc/app_state_test.dart
+++ b/flutter_news_example/test/app/bloc/app_state_test.dart
@@ -63,7 +63,7 @@ void main() {
           'authenticated and onboardingRequired are the only statuses '
           'where loggedIn it is true', () {
         expect(
-          AppStatus.values.map((e) => e.isLoggedIn).toList(),
+          AppStatus.values.where((e) => e.isLoggedIn).toList(),
           [
             AppStatus.authenticated,
             AppStatus.onboardingRequired,

--- a/flutter_news_example/test/login/widgets/login_form_test.dart
+++ b/flutter_news_example/test/login/widgets/login_form_test.dart
@@ -234,6 +234,49 @@ void main() {
         expect(find.byType(LoginWithEmailPage), findsNothing);
         expect(find.byType(LoginForm), findsNothing);
       });
+
+      testWidgets('when user is authenticated and onboarding is required',
+          (tester) async {
+        final appStateController = StreamController<AppState>();
+
+        whenListen(
+          appBloc,
+          appStateController.stream,
+          initialState: const AppState.unauthenticated(),
+        );
+
+        await tester.pumpApp(
+          Builder(
+            builder: (context) {
+              return AppButton.black(
+                child: Text(buttonText),
+                onPressed: () => showAppModal<void>(
+                  context: context,
+                  builder: (context) => BlocProvider.value(
+                    value: appBloc,
+                    child: LoginModal(),
+                  ),
+                  routeSettings: const RouteSettings(name: LoginModal.name),
+                ),
+              );
+            },
+          ),
+        );
+        await tester.tap(find.text(buttonText));
+        await tester.pumpAndSettle();
+
+        await tester.ensureVisible(find.byKey(loginButtonKey));
+        await tester.tap(find.byKey(loginButtonKey));
+        await tester.pumpAndSettle();
+        expect(find.byType(LoginWithEmailPage), findsOneWidget);
+
+        appStateController.add(AppState.onboardingRequired(user));
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        expect(find.byType(LoginWithEmailPage), findsNothing);
+        expect(find.byType(LoginForm), findsNothing);
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

There are some places where the application evaluates whether the user is logged in, but only evaluates the `AppStatus.authenticated` status and doesn't care about the `AppStatus.onboardingRequired` status.

This causes some problems, for example when the onboarding screen is shown the login modal is not dismissed.

To solve these problems I have added a getter in the `AppStatus` enum to evaluate if the user is logged in.

**Demo** 

Before


https://user-images.githubusercontent.com/18689004/217644613-bb4bdf7d-6952-4977-8da1-0956434394a9.mp4


After buy/cancel subscription the app request to login again.(see last part of the video).

After


https://user-images.githubusercontent.com/105817726/217641816-95fadc72-90e6-419d-985c-d8383af613ca.mov


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
