### PR TITLE
chore: add missing permissions for ads on Android 13

### DIFF
--- a/flutter_news_example/android/app/src/debug/AndroidManifest.xml
+++ b/flutter_news_example/android/app/src/debug/AndroidManifest.xml
@@ -5,4 +5,7 @@
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
+     <!--Required for Android 13 or above-->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+    
 </manifest>

--- a/flutter_news_example/android/app/src/main/AndroidManifest.xml
+++ b/flutter_news_example/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
          FlutterApplication and put your custom class here. -->
     <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
     <uses-permission android:name="android.permission.INTERNET"/>
+    <!--Required for Android 13 or above-->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
 
     <application
         android:name="${applicationName}"

--- a/flutter_news_example/android/app/src/profile/AndroidManifest.xml
+++ b/flutter_news_example/android/app/src/profile/AndroidManifest.xml
@@ -5,4 +5,7 @@
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
+     <!--Required for Android 13 or above-->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+    
 </manifest>


### PR DESCRIPTION
## Description

Since _Android 13_ requires **`com.google.android.gms.permission.AD_ID`** for apps containing ads, I think it would be good to include the necessary permissions and avoid problems in the deployment process.

![image](https://user-images.githubusercontent.com/18689004/217821777-0ae64ecb-2a87-4dad-8cdf-3da91d076f65.png)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
