### PR TITLE
Update html.dart

### DIFF
--- a/flutter_news_example/packages/news_blocks_ui/lib/src/html.dart
+++ b/flutter_news_example/packages/news_blocks_ui/lib/src/html.dart
@@ -21,7 +21,7 @@ class Html extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
       child: flutter_html.Html(
-        onLinkTap: (url, context, attributes, element) {
+        onLinkTap: (url, context, attributes) {
           if (url == null) return;
           final uri = Uri.tryParse(url);
           if (uri == null) return;


### PR DESCRIPTION
Error: The argument type 'void Function(String?, Map<String, String>, Element?, dynamic)' can't be assigned to the parameter type 'void Function(String?, Map<String, String>, Element?)?'.dartargument_type_not_assignable

Fix: Remove the extra 4th arguments "elements" from onLinkTap

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
