### PR TITLE
Enhancement: Disable caching in debug mode

### DIFF
--- a/flutter_news_example/lib/main/bootstrap/bootstrap.dart
+++ b/flutter_news_example/lib/main/bootstrap/bootstrap.dart
@@ -6,6 +6,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_news_example/main/bootstrap/app_bloc_observer.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
@@ -31,6 +32,11 @@ Future<void> bootstrap(AppBuilder builder) async {
   HydratedBloc.storage = await HydratedStorage.build(
     storageDirectory: await getApplicationSupportDirectory(),
   );
+
+  if (kDebugMode) {
+    await HydratedBloc.storage.clear();
+  }
+
   await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
   FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
 


### PR DESCRIPTION
The toolkit is currently using `hydrated bloc` to persist the state of certain BLoCs across app restarts or crashes.
Modified caching behavior so as to disable it in debug mode, so developers don't have to worry about seeing cached data vs fresh data.

In order to enable it, the following code must be removed from the `bootstrap.dart` file:

```dart
if (kDebugMode) {
    await HydratedBloc.storage.clear();
}
```


<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
