### PR TITLE
docs: update Dart SDK version constraints

### DIFF
--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -32,7 +32,7 @@ Depending on the number of flavors you plan to create for your project, the setu
 In order to generate a project using the news template, you must have the [Dart SDK][dart_installation_link] installed on your machine.
 
 :::info
-Dart `">=2.18.0 <3.0.0"` is required.
+Dart `">=3.0.0 <4.0.0"` is required.
 :::
 
 **Mason**


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

It seems that the example `pubspec.yaml` Dart SDK version constraints got bumped but the documentation did not.

https://github.com/flutter/news_toolkit/blob/553992b00cccd0d2e51fa9b1f71803980c1b637b/flutter_news_example/pubspec.yaml#L6

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
