### PR TITLE
Remove GoogleService-Info.plist copy in iOS project

### DIFF
--- a/flutter_news_example/ios/Runner.xcodeproj/project.pbxproj
+++ b/flutter_news_example/ios/Runner.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		CE7561891A9D31DC2D8C51C1 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF9EA78D77A8DCE8C26E6B73 /* Pods_Runner.framework */; };
-		DC98A66524D9DA07006931FA /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DC98A66424D9DA07006931FA /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -220,7 +219,6 @@
 			files = (
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
-				DC98A66524D9DA07006931FA /* GoogleService-Info.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);


### PR DESCRIPTION
## Description

The development GoogleService-Info.plist is always being copied into the Xcode bundle resources, even during a production flavor build:


![Screenshot 2024-01-04 at 6 03 32 PM](https://github.com/flutter/flutter/assets/682784/77a34c73-e4f9-45d9-8f21-e1ddb76e13f9)
![Screenshot 2024-01-04 at 6 03 21 PM](https://github.com/flutter/flutter/assets/682784/9f00bca0-d6e5-4c16-a5ae-a6c456477171)

When the template is generated with only a production flavor, the build fails:
```
Error (Xcode): Build input file cannot be found: ios/Runner/development/GoogleService-Info.plist'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?
```


Delete that copy in favor of the `Copy GoogleServices-Info.plist` build phase script, which already handles copying the right flavor variant.

Fixes https://github.com/flutter/flutter/issues/140281

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
