### PR TITLE
chore: Update Dart SDK constraint to >=3.10.0

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -16,7 +16,7 @@ jobs:
   build:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 3.9.2
+      dart_sdk: 3.10.0
       working_directory: flutter_news_example/api
       analyze_directories: "routes lib test"
       coverage_excludes: "**/*.g.dart"

--- a/.github/workflows/article_repository.yaml
+++ b/.github/workflows/article_repository.yaml
@@ -16,5 +16,5 @@ jobs:
   build:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 3.9.2
+      dart_sdk: 3.10.0
       working_directory: flutter_news_example/packages/article_repository

--- a/.github/workflows/authentication_client.yaml
+++ b/.github/workflows/authentication_client.yaml
@@ -16,5 +16,5 @@ jobs:
   build:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 3.9.2
+      dart_sdk: 3.10.0
       working_directory: flutter_news_example/packages/authentication_client/authentication_client

--- a/.github/workflows/deep_link_client.yaml
+++ b/.github/workflows/deep_link_client.yaml
@@ -16,5 +16,5 @@ jobs:
   build:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 3.9.2
+      dart_sdk: 3.10.0
       working_directory: flutter_news_example/packages/deep_link_client/deep_link_client

--- a/.github/workflows/form_inputs.yaml
+++ b/.github/workflows/form_inputs.yaml
@@ -16,5 +16,5 @@ jobs:
   build:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 3.9.2
+      dart_sdk: 3.10.0
       working_directory: flutter_news_example/packages/form_inputs

--- a/.github/workflows/news_blocks.yaml
+++ b/.github/workflows/news_blocks.yaml
@@ -17,5 +17,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
       coverage_excludes: "**/*.g.dart"
-      dart_sdk: 3.9.2
+      dart_sdk: 3.10.0
       working_directory: flutter_news_example/api/packages/news_blocks

--- a/.github/workflows/notifications_client.yaml
+++ b/.github/workflows/notifications_client.yaml
@@ -16,5 +16,5 @@ jobs:
   build:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 3.9.2
+      dart_sdk: 3.10.0
       working_directory: flutter_news_example/packages/notifications_client/notifications_client

--- a/.github/workflows/package_info_client.yaml
+++ b/.github/workflows/package_info_client.yaml
@@ -16,5 +16,5 @@ jobs:
   build:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 3.9.2
+      dart_sdk: 3.10.0
       working_directory: flutter_news_example/packages/package_info_client

--- a/.github/workflows/storage.yaml
+++ b/.github/workflows/storage.yaml
@@ -16,5 +16,5 @@ jobs:
   build:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 3.9.2
+      dart_sdk: 3.10.0
       working_directory: flutter_news_example/packages/storage/storage

--- a/.github/workflows/token_storage.yaml
+++ b/.github/workflows/token_storage.yaml
@@ -16,5 +16,5 @@ jobs:
   build:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 3.9.2
+      dart_sdk: 3.10.0
       working_directory: flutter_news_example/packages/authentication_client/token_storage

--- a/flutter_news_example/api/packages/news_blocks/pubspec.yaml
+++ b/flutter_news_example/api/packages/news_blocks/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   equatable: ^2.0.3

--- a/flutter_news_example/api/pubspec.yaml
+++ b/flutter_news_example/api/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   collection: ^1.19.0

--- a/flutter_news_example/lib/app/bloc/app_state.dart
+++ b/flutter_news_example/lib/app/bloc/app_state.dart
@@ -3,7 +3,8 @@ part of 'app_bloc.dart';
 enum AppStatus {
   onboardingRequired(),
   authenticated(),
-  unauthenticated();
+  unauthenticated()
+  ;
 
   bool get isLoggedIn =>
       this == AppStatus.authenticated || this == AppStatus.onboardingRequired;

--- a/flutter_news_example/lib/home/cubit/home_state.dart
+++ b/flutter_news_example/lib/home/cubit/home_state.dart
@@ -3,7 +3,8 @@ part of 'home_cubit.dart';
 enum HomeState {
   topStories(0),
   search(1),
-  subscribe(2);
+  subscribe(2)
+  ;
 
   const HomeState(this.tabIndex);
   final int tabIndex;

--- a/flutter_news_example/packages/ads_consent_client/pubspec.yaml
+++ b/flutter_news_example/packages/ads_consent_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/flutter_news_example/packages/analytics_repository/pubspec.yaml
+++ b/flutter_news_example/packages/analytics_repository/pubspec.yaml
@@ -3,7 +3,7 @@ description: Package which manages the analytics domain.
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   equatable: ^2.0.0

--- a/flutter_news_example/packages/app_ui/gallery/pubspec.yaml
+++ b/flutter_news_example/packages/app_ui/gallery/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   app_ui:

--- a/flutter_news_example/packages/app_ui/pubspec.yaml
+++ b/flutter_news_example/packages/app_ui/pubspec.yaml
@@ -3,7 +3,7 @@ description: App UI Component Library
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/flutter_news_example/packages/article_repository/pubspec.yaml
+++ b/flutter_news_example/packages/article_repository/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   clock: ^1.1.1

--- a/flutter_news_example/packages/authentication_client/authentication_client/pubspec.yaml
+++ b/flutter_news_example/packages/authentication_client/authentication_client/pubspec.yaml
@@ -3,7 +3,7 @@ description: An Authentication Client Interface
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   equatable: ^2.0.3

--- a/flutter_news_example/packages/authentication_client/firebase_authentication_client/pubspec.yaml
+++ b/flutter_news_example/packages/authentication_client/firebase_authentication_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   authentication_client:

--- a/flutter_news_example/packages/authentication_client/token_storage/pubspec.yaml
+++ b/flutter_news_example/packages/authentication_client/token_storage/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dev_dependencies:
   coverage: ^1.3.2

--- a/flutter_news_example/packages/deep_link_client/deep_link_client/pubspec.yaml
+++ b/flutter_news_example/packages/deep_link_client/deep_link_client/pubspec.yaml
@@ -3,7 +3,7 @@ description: A deep link client interface
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   equatable: ^2.0.5

--- a/flutter_news_example/packages/deep_link_client/firebase_deep_link_client/pubspec.yaml
+++ b/flutter_news_example/packages/deep_link_client/firebase_deep_link_client/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Dart package which provides a deep link stream
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   deep_link_client:

--- a/flutter_news_example/packages/email_launcher/pubspec.yaml
+++ b/flutter_news_example/packages/email_launcher/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   android_intent_plus: ^5.0.1

--- a/flutter_news_example/packages/form_inputs/pubspec.yaml
+++ b/flutter_news_example/packages/form_inputs/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Dart package which exposes reusable form inputs and validation ru
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   formz: ^0.8.0

--- a/flutter_news_example/packages/in_app_purchase_repository/pubspec.yaml
+++ b/flutter_news_example/packages/in_app_purchase_repository/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   authentication_client:

--- a/flutter_news_example/packages/news_blocks_ui/pubspec.yaml
+++ b/flutter_news_example/packages/news_blocks_ui/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   app_ui:

--- a/flutter_news_example/packages/news_repository/pubspec.yaml
+++ b/flutter_news_example/packages/news_repository/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   equatable: ^2.0.3

--- a/flutter_news_example/packages/notifications_client/firebase_notifications_client/pubspec.yaml
+++ b/flutter_news_example/packages/notifications_client/firebase_notifications_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   firebase_messaging: ^15.2.8

--- a/flutter_news_example/packages/notifications_client/notifications_client/pubspec.yaml
+++ b/flutter_news_example/packages/notifications_client/notifications_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dev_dependencies:
   test: ^1.21.4

--- a/flutter_news_example/packages/notifications_client/one_signal_notifications_client/pubspec.yaml
+++ b/flutter_news_example/packages/notifications_client/one_signal_notifications_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/flutter_news_example/packages/notifications_repository/pubspec.yaml
+++ b/flutter_news_example/packages/notifications_repository/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   equatable: ^2.0.3

--- a/flutter_news_example/packages/package_info_client/pubspec.yaml
+++ b/flutter_news_example/packages/package_info_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   equatable: ^2.0.3

--- a/flutter_news_example/packages/permission_client/pubspec.yaml
+++ b/flutter_news_example/packages/permission_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/flutter_news_example/packages/purchase_client/pubspec.yaml
+++ b/flutter_news_example/packages/purchase_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   clock: ^1.1.1

--- a/flutter_news_example/packages/share_launcher/pubspec.yaml
+++ b/flutter_news_example/packages/share_launcher/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   equatable: ^2.0.3

--- a/flutter_news_example/packages/storage/persistent_storage/pubspec.yaml
+++ b/flutter_news_example/packages/storage/persistent_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Storage that saves data in the device's persistent memory.
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/flutter_news_example/packages/storage/secure_storage/pubspec.yaml
+++ b/flutter_news_example/packages/storage/secure_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Key/Value Secure Storage Client
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/flutter_news_example/packages/storage/storage/pubspec.yaml
+++ b/flutter_news_example/packages/storage/storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Key/Value Storage Client for Dart.
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dev_dependencies:
   test: ^1.21.4

--- a/flutter_news_example/packages/user_repository/pubspec.yaml
+++ b/flutter_news_example/packages/user_repository/pubspec.yaml
@@ -3,7 +3,7 @@ description: Dart package which manages the user domain.
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   authentication_client:

--- a/flutter_news_example/pubspec.yaml
+++ b/flutter_news_example/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.0.1+1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
   flutter: ">=3.38.3"
 
 dependencies:


### PR DESCRIPTION
## Summary
- Update Dart SDK constraint from `>=3.9.2` to `>=3.10.0` across all packages
- Aligns with Flutter 3.38.3 which ships with Dart 3.10.1

## Test plan
- [x] Verify all CI workflows pass