### PR TITLE
fix: remove felangel from reviewers in template workflow

### DIFF
--- a/.github/workflows/generate_flutter_news_template.yaml
+++ b/.github/workflows/generate_flutter_news_template.yaml
@@ -56,5 +56,4 @@ jobs:
           title: "chore: generate flutter_news_template"
           body: Please squash and merge me!
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          reviewers: felangel
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
## Summary
- Removes `felangel` from the reviewers list in the `generate_flutter_news_template` workflow

## Context
The `generate_flutter_news_template` workflow has been failing because it tries to request a review from `felangel`, who is no longer a collaborator on the repository. The workflow successfully creates the PR but fails at the final step with:

```
Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the VGVentures/news_toolkit repository.
```

This fix removes the reviewer to allow the workflow to complete successfully. A reviewer can be added back later if needed.