### PR TITLE
fix: update generate script to use build.gradle.kts

### DIFF
--- a/tool/generator/main.dart
+++ b/tool/generator/main.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+
 import 'package:path/path.dart' as path;
 
 final _staticDir = path.join('tool', 'generator', 'static');
@@ -154,8 +155,8 @@ void main() async {
     path.join(_targetPath, '.vscode', 'launch.json'),
   );
   await Shell.cp(
-    path.join(_staticDir, 'build.gradle'),
-    path.join(_targetPath, 'android', 'app', 'build.gradle'),
+    path.join(_staticDir, 'build.gradle.kts'),
+    path.join(_targetPath, 'android', 'app', 'build.gradle.kts'),
   );
   await Shell.cp('codemagic.yaml', _targetCodemagic);
 


### PR DESCRIPTION
## Description

The generate script is failing in main because the `build.gradle` no longer exists since it was replaced with `build.gradle.kts`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
